### PR TITLE
Add "many" version of API calls for UpdateMagicTransitGRETunnels, CreateMagicTransitStaticRoutes & UpdateMagicTransitStaticRoutes

### DIFF
--- a/magic_transit_gre_tunnel.go
+++ b/magic_transit_gre_tunnel.go
@@ -58,6 +58,11 @@ type CreateMagicTransitGRETunnelsRequest struct {
 	GRETunnels []MagicTransitGRETunnel `json:"gre_tunnels"`
 }
 
+// UpdateMagicTransitGRETunnelsRequest is an array of GRE tunnels to update.
+type UpdateMagicTransitGRETunnelsRequest struct {
+	GRETunnels []MagicTransitGRETunnel `json:"gre_tunnels"`
+}
+
 // UpdateMagicTransitGRETunnelResponse contains a response after updating a GRE Tunnel.
 type UpdateMagicTransitGRETunnelResponse struct {
 	Response
@@ -154,6 +159,27 @@ func (api *API) UpdateMagicTransitGRETunnel(ctx context.Context, accountID strin
 	}
 
 	return result.Result.ModifiedGRETunnel, nil
+}
+
+// UpdateMagicTransitGRETunnel updates a GRE tunnel.
+//
+// API reference: https://api.cloudflare.com/#magic-gre-tunnels-update-multiple-gre-tunnels
+func (api *API) UpdateMagicTransitGRETunnels(ctx context.Context, accountID string, tunnels []MagicTransitGRETunnel) ([]MagicTransitGRETunnel, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/gre_tunnels", accountID)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, UpdateMagicTransitGRETunnelsRequest{
+		GRETunnels: tunnels,
+	})
+
+	if err != nil {
+		return []MagicTransitGRETunnel{}, err
+	}
+
+	result := ListMagicTransitGRETunnelsResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []MagicTransitGRETunnel{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result.GRETunnels, nil
 }
 
 // DeleteMagicTransitGRETunnel deletes a GRE tunnel.

--- a/magic_transit_gre_tunnel_test.go
+++ b/magic_transit_gre_tunnel_test.go
@@ -267,6 +267,72 @@ func TestUpdateMagicTransitGRETunnel(t *testing.T) {
 	}
 }
 
+func TestUpdateMagicTransitGRETunnels(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "gre_tunnels": [
+          {
+            "id": "c4a7362d577a6c3019a474fd6f485821",
+            "created_on": "2017-06-14T00:00:00Z",
+            "modified_on": "2017-06-14T05:20:00Z",
+            "name": "GRE_1",
+            "customer_gre_endpoint": "203.0.113.1",
+            "cloudflare_gre_endpoint": "203.0.113.2",
+            "interface_address": "192.0.2.0/31",
+            "description": "Tunnel for ISP X",
+            "ttl": 64,
+            "mtu": 1476,
+            "health_check": {
+              "enabled": true,
+              "target": "203.0.113.1",
+              "type": "request"
+            }
+          }
+        ]
+      }
+    }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/gre_tunnels", handler)
+
+	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
+
+	want := []MagicTransitGRETunnel{
+		{
+			ID:                    "c4a7362d577a6c3019a474fd6f485821",
+			CreatedOn:             &createdOn,
+			ModifiedOn:            &modifiedOn,
+			Name:                  "GRE_1",
+			CustomerGREEndpoint:   "203.0.113.1",
+			CloudflareGREEndpoint: "203.0.113.2",
+			InterfaceAddress:      "192.0.2.0/31",
+			Description:           "Tunnel for ISP X",
+			TTL:                   64,
+			MTU:                   1476,
+			HealthCheck: &MagicTransitGRETunnelHealthcheck{
+				Enabled: true,
+				Target:  "203.0.113.1",
+				Type:    "request",
+			},
+		},
+	}
+
+	actual, err := client.UpdateMagicTransitGRETunnels(context.Background(), testAccountID, want)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
 func TestDeleteMagicTransitGRETunnel(t *testing.T) {
 	setup()
 	defer teardown()

--- a/magic_transit_static_routes.go
+++ b/magic_transit_static_routes.go
@@ -68,8 +68,27 @@ type DeleteMagicTransitStaticRouteResponse struct {
 	} `json:"result"`
 }
 
+// DeleteMagicTransitStaticRouteResponse contains a static route deletion response.
+type DeleteMagicTransitStaticRoutesResponse struct {
+	Response
+	Result struct {
+		Deleted       bool                      `json:"deleted"`
+		DeletedRoutes []MagicTransitStaticRoute `json:"deleted_routes"`
+	} `json:"result"`
+}
+
 // CreateMagicTransitStaticRoutesRequest is an array of static routes to create.
 type CreateMagicTransitStaticRoutesRequest struct {
+	Routes []MagicTransitStaticRoute `json:"routes"`
+}
+
+// UpdateMagicTransitStaticRoutesRequest is an array of static routes updated.
+type UpdateMagicTransitStaticRoutesRequest struct {
+	Routes []MagicTransitStaticRoute `json:"routes"`
+}
+
+// DeleteMagicTransitStaticRoutesRequest is an array of static routes to delete.
+type DeleteMagicTransitStaticRoutesRequest struct {
 	Routes []MagicTransitStaticRoute `json:"routes"`
 }
 
@@ -132,6 +151,27 @@ func (api *API) CreateMagicTransitStaticRoute(ctx context.Context, accountID str
 	return result.Result.Routes, nil
 }
 
+// CreateMagicTransitStaticRoutes creates new static routes
+//
+// API reference: https://api.cloudflare.com/#magic-transit-static-routes-create-routes
+func (api *API) CreateMagicTransitStaticRoutes(ctx context.Context, accountID string, routes []MagicTransitStaticRoute) ([]MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes", accountID)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, CreateMagicTransitStaticRoutesRequest{
+		Routes: routes,
+	})
+
+	if err != nil {
+		return []MagicTransitStaticRoute{}, err
+	}
+
+	result := ListMagicTransitStaticRoutesResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []MagicTransitStaticRoute{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result.Routes, nil
+}
+
 // UpdateMagicTransitStaticRoute updates a static route
 //
 // API reference: https://api.cloudflare.com/#magic-transit-static-routes-update-route
@@ -155,6 +195,27 @@ func (api *API) UpdateMagicTransitStaticRoute(ctx context.Context, accountID, ID
 	return result.Result.ModifiedRoute, nil
 }
 
+// UpdateMagicTransitStaticRoutes updates static routes
+//
+// API reference: https://api.cloudflare.com/#magic-transit-static-routes-update-route
+func (api *API) UpdateMagicTransitStaticRoutes(ctx context.Context, accountID string, routes []MagicTransitStaticRoute) ([]MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes", accountID)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, UpdateMagicTransitStaticRoutesRequest{
+		Routes: routes,
+	})
+
+	if err != nil {
+		return []MagicTransitStaticRoute{}, err
+	}
+
+	result := ListMagicTransitStaticRoutesResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []MagicTransitStaticRoute{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result.Routes, nil
+}
+
 // DeleteMagicTransitStaticRoute deletes a static route
 //
 // API reference: https://api.cloudflare.com/#magic-transit-static-routes-delete-route
@@ -176,4 +237,29 @@ func (api *API) DeleteMagicTransitStaticRoute(ctx context.Context, accountID, ID
 	}
 
 	return result.Result.DeletedRoute, nil
+}
+
+// DeleteMagicTransitStaticRoutes deletes static routes
+//
+// API reference: https://api.cloudflare.com/#magic-static-routes-delete-many-routes
+func (api *API) DeleteMagicTransitStaticRoutes(ctx context.Context, accountID string, routes []MagicTransitStaticRoute) ([]MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes", accountID)
+	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, DeleteMagicTransitStaticRoutesRequest{
+		Routes: routes,
+	})
+
+	if err != nil {
+		return []MagicTransitStaticRoute{}, err
+	}
+
+	result := DeleteMagicTransitStaticRoutesResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []MagicTransitStaticRoute{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	if !result.Result.Deleted {
+		return []MagicTransitStaticRoute{}, errors.New(errMagicTransitStaticRouteNotDeleted)
+	}
+
+	return result.Result.DeletedRoutes, nil
 }

--- a/magic_transit_static_routes_test.go
+++ b/magic_transit_static_routes_test.go
@@ -142,7 +142,7 @@ func TestGetMagicTransitStaticRoute(t *testing.T) {
 	}
 }
 
-func TestCreateMagicTransitStaticRoutes(t *testing.T) {
+func TestCreateMagicTransitStaticRoute(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -207,6 +207,73 @@ func TestCreateMagicTransitStaticRoutes(t *testing.T) {
 		assert.Equal(t, []MagicTransitStaticRoute{
 			want,
 		}, actual)
+	}
+}
+func TestCreateMagicTransitStaticRoutes(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "routes": [
+          {
+            "id": "c4a7362d577a6c3019a474fd6f485821",
+            "created_on": "2017-06-14T00:00:00Z",
+            "modified_on": "2017-06-14T05:20:00Z",
+            "prefix": "192.0.2.0/24",
+            "nexthop": "203.0.113.1",
+            "priority": 100,
+            "description": "New route for new prefix 203.0.113.1",
+            "weight": 100,
+            "scope": {
+              "colo_regions": [
+                "APAC"
+              ],
+              "colo_names": [
+                "den01"
+              ]
+            }
+          }
+        ]
+      }
+    }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes", handler)
+
+	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
+
+	want := []MagicTransitStaticRoute{
+		{
+			ID:          "c4a7362d577a6c3019a474fd6f485821",
+			CreatedOn:   &createdOn,
+			ModifiedOn:  &modifiedOn,
+			Prefix:      "192.0.2.0/24",
+			Nexthop:     "203.0.113.1",
+			Priority:    100,
+			Description: "New route for new prefix 203.0.113.1",
+			Weight:      100,
+			Scope: MagicTransitStaticRouteScope{
+				ColoRegions: []string{
+					"APAC",
+				},
+				ColoNames: []string{
+					"den01",
+				},
+			},
+		},
+	}
+
+	actual, err := client.CreateMagicTransitStaticRoutes(context.Background(), testAccountID, want)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
 	}
 }
 
@@ -275,6 +342,74 @@ func TestUpdateMagicTransitStaticRoute(t *testing.T) {
 	}
 }
 
+func TestUpdateMagicTransitStaticRoutes(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "routes": [
+          {
+            "id": "c4a7362d577a6c3019a474fd6f485821",
+            "created_on": "2017-06-14T00:00:00Z",
+            "modified_on": "2017-06-14T05:20:00Z",
+            "prefix": "192.0.2.0/24",
+            "nexthop": "203.0.113.1",
+            "priority": 100,
+            "description": "New route for new prefix 203.0.113.1",
+            "weight": 100,
+            "scope": {
+              "colo_regions": [
+                "APAC"
+              ],
+              "colo_names": [
+                "den01"
+              ]
+            }
+          }
+        ]
+      }
+    }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes", handler)
+
+	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
+
+	want := []MagicTransitStaticRoute{
+		{
+			ID:          "c4a7362d577a6c3019a474fd6f485821",
+			CreatedOn:   &createdOn,
+			ModifiedOn:  &modifiedOn,
+			Prefix:      "192.0.2.0/24",
+			Nexthop:     "203.0.113.1",
+			Priority:    100,
+			Description: "New route for new prefix 203.0.113.1",
+			Weight:      100,
+			Scope: MagicTransitStaticRouteScope{
+				ColoRegions: []string{
+					"APAC",
+				},
+				ColoNames: []string{
+					"den01",
+				},
+			},
+		},
+	}
+
+	actual, err := client.UpdateMagicTransitStaticRoutes(context.Background(), testAccountID, want)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
 func TestDeleteMagicTransitStaticRoute(t *testing.T) {
 	setup()
 	defer teardown()
@@ -335,6 +470,72 @@ func TestDeleteMagicTransitStaticRoute(t *testing.T) {
 	}
 
 	actual, err := client.DeleteMagicTransitStaticRoute(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeleteMagicTransitStaticRoutes(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "deleted": true,
+        "deleted_routes": [{
+          "id": "c4a7362d577a6c3019a474fd6f485821",
+          "created_on": "2017-06-14T00:00:00Z",
+          "modified_on": "2017-06-14T05:20:00Z",
+          "prefix": "192.0.2.0/24",
+          "nexthop": "203.0.113.1",
+          "priority": 100,
+          "description": "New route for new prefix 203.0.113.1",
+          "weight": 100,
+          "scope": {
+            "colo_regions": [
+              "APAC"
+            ],
+            "colo_names": [
+              "den01"
+            ]
+          }
+        }]
+      }
+    }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes", handler)
+
+	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
+
+	want := []MagicTransitStaticRoute{{
+		ID:          "c4a7362d577a6c3019a474fd6f485821",
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Prefix:      "192.0.2.0/24",
+		Nexthop:     "203.0.113.1",
+		Priority:    100,
+		Description: "New route for new prefix 203.0.113.1",
+		Weight:      100,
+		Scope: MagicTransitStaticRouteScope{
+			ColoRegions: []string{
+				"APAC",
+			},
+			ColoNames: []string{
+				"den01",
+			},
+		},
+	}}
+
+	actual, err := client.DeleteMagicTransitStaticRoutes(context.Background(), testAccountID,
+		[]MagicTransitStaticRoute{{ID: "c4a7362d577a6c3019a474fd6f485821"}})
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}


### PR DESCRIPTION
## Description

During work automating Magic Transit GRE Tunnel & Magic Transit Static Route setup, I discovered missing go wrappers that accepted multiple items.

The "many" versions I found absent were:
UpdateMagicTransitGRETunnels https://api.cloudflare.com/#magic-gre-tunnels-update-multiple-gre-tunnels
CreateMagicTransitStaticRoutes https://api.cloudflare.com/#magic-static-routes-create-routes
UpdateMagicTransitStaticRoutes https://api.cloudflare.com/#magic-static-routes-update-many-routes
DeleteMagicTransitStaticRoutes https://api.cloudflare.com/#magic-static-routes-delete-many-routes

Without these, iterating over larger sets with the single item calls is painfully slow.

## Has your change been tested?

Automated tests mimicking other multi-item versions have been added.
These added calls are currently being used in our internal setup tool.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
